### PR TITLE
Update snapcraft.yaml and fix Black Screen Client

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: valorant
 version: '1.0'
-summary: valorant is FPS 5x5 game developed and published by Riot Games.
-description: valorant is FPS 5x5 game developed and published by Riot Games.
+summary: Valorant is FPS 5x5 game developed and published by Riot Games.
+description: Valorant is FPS 5x5 game developed and published by Riot Games.
 
 grade: stable
 confinement: devmode
@@ -84,7 +84,7 @@ apps:
       INSTALL_URL_RU: "http://valorant.secure.dyn.riotcdn.net/channels/public/x/installer/current/live.exe"
       INSTALL_URL_TR: "http://valorant.secure.dyn.riotcdn.net/channels/public/x/installer/current/live.exe"
       INSTALL_URL_PBE: "http://valorant.secure.dyn.riotcdn.net/channels/public/x/installer/current/live.exe"
-      TRICKS: "d3dx9"
+      TRICKS: "d3dx9,dxvk191"
       LC_ALL: "C.UTF-8"
     plugs:
       - desktop


### PR DESCRIPTION
I made a few capitalization errors and included a new wine trick to combat the black screen that comes with Riot CEF 91(thanks Riot). While I'm here, I found [this ](https://snapcraft.io/install/wine-platform-6-stable/ubuntu)by the same guy who made League Of Legends snap. I think we can combat the kernel anti-cheat by using Wine 6 but I would like to get thoughts on this.